### PR TITLE
Prefer using `/etc/systemd/system/` for unit files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,4 +11,4 @@ docker_mounts: []
 docker_environment: {}
 docker_ports: []
 
-systemd_install_path: /usr/lib/systemd/system
+systemd_install_path: /etc/systemd/system


### PR DESCRIPTION
the path `/etc/systemd/system/` is used on both RHEL and Debian based distros, for user/sysadmin configured units.
`/lib/systemd/system/` is intended for units installed by system packages.
`/usr/lib/systemd/system/` is created via symlink on RHEL based distros, but not present on debian based ones.
See https://www.freedesktop.org/software/systemd/man/systemd.unit.html for reference.