### PR TITLE
ensure daemon reload before restarting service

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,11 +1,7 @@
 ---
 - name: restart service
   become: yes
-  service:
+  ansible.builtin.systemd_service:
     name: "{{ service_name }}"
+    daemon_reload: true
     state: restarted
-
-- name: reload systemd daemon
-  become: yes
-  systemd:
-    daemon_reload: yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,12 +20,14 @@
     src: systemd.service.j2
     dest: "{{ systemd_install_path }}/{{ service_name }}.service"
   notify:
-    - reload systemd daemon
     - restart service
 
-- name: Enable service.
+- name: flush_handlers
+  meta: flush_handlers
+
+- name: Ensure service is started and enabled
   become: yes
-  service:
+  ansible.builtin.systemd_service:
     name: "{{ service_name }}"
+    enabled: true
     state: started
-    enabled: True


### PR DESCRIPTION
when daemon reload and service restart were in separate handlers, often the old version of the service would be restarted. Refactor to use the systemd module and do both in one step.

Also flush handlers prior to ensuring service is running, this will prevent attempting to start the service with an old configuration prior to the daemon reload.